### PR TITLE
Remove assumption that the table of contents will be an <ol>.

### DIFF
--- a/spec_splitter.py
+++ b/spec_splitter.py
@@ -148,16 +148,16 @@ def main(input, output):
   del short_header[1:]
 
   # Extract the items in the TOC (remembering their nesting depth)
-  def extract_toc_items(items, ol, depth):
-      for li in ol.iterchildren():
+  def extract_toc_items(items, toc, depth):
+      for li in toc.iterchildren():
           for c in li.iterchildren():
               if c.tag == 'a':
                 if c.get('href')[0] == '#':
                   items.append( (depth, c.get('href')[1:], c) )
-              elif c.tag == 'ol':
+              elif c.tag in ('ol', 'ul'):
                   extract_toc_items(items, c, depth+1)
   toc_items = []
-  extract_toc_items(toc_items, original_body.find('.//ol[@class="toc"]'), 0)
+  extract_toc_items(toc_items, original_body.find('.//*[@class="toc"]'), 0)
 
   # Stuff for fixing up references:
 


### PR DESCRIPTION
A recent change to anolis[1] caused it to output the table of contents
using `<ul>` tags instead of `<ol>` tags, breaking the generation of the
table of contents for individual pages.

Instead, we now search for the table of contents by the toc class
without assuming what tag it will use.

[1] https://bitbucket.org/ms2ger/anolis/commits/62d9a108439d70e33ad2bb3b4009efd3dbf9cac5
