### PR TITLE
es6-promise is needed from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,6 @@
     "dependencies": {
         "nightmare": "*"
     ,   "vo": "*"
+    ,   "es6-promise": "*"
     }
 }


### PR DESCRIPTION
package.json doesn't include es6-promise, which is used by io-promise.js. Without this, npm doesn't install all the dependencies.