### PR TITLE
Fix for HTML issue: https://github.com/w3c/html/issues/833

### DIFF
--- a/multipage.js
+++ b/multipage.js
@@ -141,6 +141,9 @@ for(var i=0; i<sections.length; i++) {
     newSection.append(s);
     section.node = newSection;
   }
+  // Serialize to string to avoid uncollectable jQuery object graphs when mixed into another
+  // document later. See https://github.com/w3c/html/issues/833
+  section.node = "<section>" + section.node.html() + "</section>";
 }
 
 console.log("Generating index");
@@ -177,10 +180,10 @@ for(var i=0; i<sections.length; i++) {
 
 	var doc = whacko.load(sectionDocument);
 
-  var section = sections[i].node;
+  var sectionString = sections[i].node;
 
   // insert the proper section
-  var main = doc("main").first().append(section);
+  var main = doc("main").first().append(sectionString);
 
   // Adjust the table of contents
 	var toc = doc("nav#toc ol").first();


### PR DESCRIPTION
Fixes an issue of linear memory growth in the NodeJS multipage.js script
which was causing out-of-memory exceptions on Windows. After testing the
issue, I discovered that the splitter reaches about 2GB of memory and then
fails to complete due to the inability of the NodeJS GC to allocate objects.
I also noticed that the splitter became progressively slower as each new
section was generated.

The HTML build process executes the splitter with a few flags (that appear
to have worked around the problem?):

`node --max_old_space_size=2048 --expose-gc ./tools/multipage.js single-page.html ./out/`

After reviewing the splitter script's code, it became apparent that there was a memory
growth problem in the way that several "whacko" documents were being linked together in
the final section-building loop. The memory structure was basically the following:

```
sections = [
  {
     id: <string>,
     title: <string>,
     node: <ref to a section from single_page.html whacko document>
  }
];
```

As each section building loop ran, the code placed the section[i].node into a new
whacko document representing the template skeleton for that section.

```
<template whacko document>
 <nodes in template whacko document>
  ..
   <ref to single_page.html whacko document>
 </..>
</..>
```

Apparently, the way that a whacko document works is that it use jQuery under-the-hood,
and jQuery links nodes into the document tree in a graph of relationships such that
the inclusion of a ref to the single_page.html's whacko document meant that the
section[i].node reference was now keeping the entire `<template whacko document>` alive.
As each new `<template whacko document>` was created and had pieces of it mixed in from
`<singe_page.html whacko document>` the prior document was unable to be collected, and
memory continued to grow.

The change serializes the section[i].node contents so that there is no GC graph link
possible between whacko documents. Sure enough, the GC is able to kick in and I see
memory growth hit 1GB and then drop back to 500MB in cycles.